### PR TITLE
feat(renovate): patch/minor 更新を minimumReleaseAge 経過後に自動マージする

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,15 @@
   "pre-commit": {
     "enabled": true
   },
+  "minimumReleaseAge": "7 days",
+  "packageRules": [
+    {
+      "description": "patch/minor は minimumReleaseAge (7日) 経過後、CI green を条件に自動マージする。major は供給網攻撃対策の猶予期間だけでは不十分なため対象外とし、人手レビューを必須とする",
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true,
+      "automergeType": "pr"
+    }
+  ],
   "nodenv": {
     "description": ".node-version はメジャーのみを保持する。パッチ追従と mise.lock の再解決は mise-lock.yaml (週次) が行い、Renovate はメジャー更新の提案のみ担う。mise.lock は mise-lock.yaml が .node-version 変更 PR に追従 commit して同期する",
     "enabled": true


### PR DESCRIPTION
## 概要

Renovate の automerge を使えるようにする renovate.json 設定。

## 変更内容

- `minimumReleaseAge: "7 days"` を追加。公開7日未満のバージョンは更新提案自体の対象外にする (供給網攻撃対策、脆弱性修正 PR はこの猶予期間の対象外で即座に上がる)
- `packageRules` で patch/minor 更新のみ `automerge: true` / `automergeType: "pr"`。major は対象外とし人手レビューを必須とする

## 関連 Issue

なし

## 動作確認

- `python3 -m json.tool renovate.json` で JSON として妥当なことを確認
- pre-commit hook 通過済み

## チェックリスト

- [ ] テストを追加・更新した
- [ ] ドキュメントを更新した
- [ ] 破壊的変更が含まれる場合、その影響範囲を明記した

## 補足情報

このリポジトリは `allow_auto_merge` を今回あわせて有効化した (元は false)。