### PR TITLE
fix(blog): dprint に空化された /blog 一覧ページを復元する

### DIFF
--- a/src/lib/excerpt.ts
+++ b/src/lib/excerpt.ts
@@ -1,0 +1,10 @@
+// NOTE: この正規表現群 (特に文字クラス内のバッククォート) を .astro の frontmatter に置くと
+// dprint の markup_fmt プラグインが字句解析に失敗しファイル全体を空に整形するため、.ts に分離している
+export function excerpt(body: string, length = 200): string {
+  const plain = body
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/[#>*_`~[\]()!-]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return plain.length > length ? `${plain.slice(0, length)}…` : plain;
+}

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,3 +1,27 @@
 ---
+import { getCollection } from "astro:content";
+import BlogList from "../../components/BlogList/BlogList";
+import Base from "../../layouts/Base.astro";
+import { excerpt } from "../../lib/excerpt";
 
+const posts = (await getCollection("blog"))
+  .sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
+  .map((post) => ({
+    id: post.id,
+    title: post.data.title,
+    date: post.data.date.toISOString(),
+    slug: post.data.slug,
+    tags: post.data.tags,
+    description: post.data.description ?? excerpt(post.body ?? ""),
+  }));
 ---
+
+<Base
+  title="Blog | Mizuki Sango - Portfolio"
+  ogTitle="Blog | Mizuki Sango"
+  description="技術記事やプロジェクトの記録"
+  canonical="https://msageha.net/blog/"
+  ogImage={new URL("/og/blog.png", Astro.site).href}
+>
+  <BlogList client:load posts={posts} />
+</Base>


### PR DESCRIPTION
## 概要

`/blog` にアクセスすると真っ白な画面になる問題を修正します。

a484899 (#66) の `dprint fmt` 適用時に `src/pages/blog/index.astro` が frontmatter 区切りだけの空ファイル (9 バイト) に整形され、ビルド結果の `dist/blog/index.html` が 0 バイトになっていました。

原因は dprint の markup_fmt プラグイン (v0.27.3) のバグです。frontmatter 内の正規表現の文字クラスに単独のバッククォート (`excerpt()` の Markdown 記号除去用 regex) があると字句解析に失敗し、エラーを出さずにファイル全体を空に整形します。`dprint fmt --stdin` で当該 regex 1 行のみの最小再現を確認済みで、バッククォートのエスケープでは回避できません。同じコードでも `.ts` ファイルなら TypeScript プラグインが正しく処理します。

## 変更内容

- `src/pages/blog/index.astro` を a484899 直前の内容から復元
- バッククォートを含む `excerpt()` を `src/lib/excerpt.ts` に分離し、frontmatter からバッククォートを排除 (dprint excludes への追加は当該ファイルが永久に未整形になるため不採用)
- 分離に伴い eslint `no-useless-escape` 指摘 (`\[`) を修正

## 関連 Issue

なし (upstream の g-plane/markup_fmt へのバグ報告は別途検討)

## 動作確認

- `dprint fmt` を通してもファイルが空化されないことを確認 (import 並び替えのみ)
- `npm run fmt:check` / `lint` / `typecheck` すべて成功
- `npm run build` 成功、`dist/blog/index.html` が 0 → 30,969 バイト
- `astro preview` + Playwright で実地確認: `/blog` に記事一覧が表示され、コンソールエラー 0 件、個別記事への遷移も正常

## チェックリスト

- [ ] テストを追加・更新した
- [ ] ドキュメントを更新した
- [x] 破壊的変更が含まれる場合、その影響範囲を明記した (破壊的変更なし)

## 補足情報

markup_fmt は構文エラー時に空出力を返し、dprint がそれをそのまま書き込むため、同種の被害は他ファイルでも起こり得ます。frontmatter に奇数個のバッククォートを含むリテラルを書かない限りは安全です。