### PR TITLE
feat(headers): public/_headers でセキュリティヘッダとキャッシュ戦略を配信する

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,29 @@
+# セキュリティヘッダ (msageha/portfolio#67)。参照実装: dope-corp/web-app の public/_headers。
+# CSP 本体 (script-src 等) は Astro islands の inline script や Satori 生成画像などサイト実態に
+# 合わせた調整が必要なため未導入。meta CSP で表現できない frame-ancestors のみここで配信する。
+#
+# 運用メモ:
+# - /_astro/* は immutable 1 年キャッシュのため、ファイル名 (=内容) が変わらずヘッダだけ変える
+#   デプロイは既存訪問者のキャッシュ済み資産に反映されない。ヘッダ変更はファイル名が変わる
+#   デプロイに載せて確認すること。
+# - 同一パスに複数ルールがマッチすると同名ヘッダは連結される仕様のため、Cache-Control は /* に
+#   置かない。HTML は Pages 既定 (Cache-Control 無し + ETag 再検証) のままとする。
+
+# Strict-Transport-Security: preload は msageha.net 配下全体への影響が未確認のため付けない。
+/*
+  Content-Security-Policy: frame-ancestors 'none'
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: microphone=(), camera=(), geolocation=(), display-capture=(), payment=(), usb=()
+  Strict-Transport-Security: max-age=31536000; includeSubDomains
+  Cross-Origin-Opener-Policy: same-origin
+
+# Astro のハッシュ付きビルド資産は内容が変わればファイル名も変わるため immutable キャッシュにする
+/_astro/*
+  Cache-Control: public, max-age=31536000, immutable
+
+# Pagefind は pagefind.js 等のハッシュ無しファイルとハッシュ付き index が相互依存するため、
+# デプロイ跨ぎのバージョン混在を避けて毎回 ETag 再検証させる (未変更時は 304)
+/pagefind/*
+  Cache-Control: public, no-cache


### PR DESCRIPTION
## 概要

Cloudflare Pages 既定のヘッダのみでセキュリティヘッダが無い状態を解消する (#67)。dope-corp/web-app の `public/_headers` を参照実装として、最小構成のセキュリティヘッダとキャッシュ戦略を追加する。

## 変更内容

- `public/_headers` を新規追加
  - 全パス: `Content-Security-Policy: frame-ancestors 'none'` / `X-Frame-Options: DENY` / `X-Content-Type-Options: nosniff` / `Referrer-Policy: strict-origin-when-cross-origin` / `Permissions-Policy` (全 deny) / `Strict-Transport-Security` (preload なし) / `Cross-Origin-Opener-Policy: same-origin`
  - `/_astro/*`: `public, max-age=31536000, immutable` (ハッシュ付きファイル名のため安全)
  - `/pagefind/*`: `public, no-cache` (ハッシュ無し本体とハッシュ付き index のデプロイ跨ぎバージョン混在を防ぐため毎回 ETag 再検証)
- CSP 本体 (script-src 等) は Astro islands の inline script / Satori 生成画像などサイト実態に合わせた調整が必要なため今回は見送り (issue 記載どおり)

## 関連 Issue

Closes #67

## 動作確認

- `npm run build` で `dist/_headers` に取り込まれることを確認
- `wrangler pages dev dist` に対する実測で以下を確認:
  - `/` : 上記セキュリティヘッダすべてが付与される
  - `/_astro/App.DooIePPC.js` : `cache-control: public, max-age=31536000, immutable`
  - `/pagefind/pagefind.js` : `cache-control: public, no-cache`
- merge 後に本番 (https://msageha.net) のレスポンスヘッダを実測確認する

## チェックリスト

- [ ] テストを追加・更新した
- [ ] ドキュメントを更新した
- [x] 破壊的変更が含まれる場合、その影響範囲を明記した

## 補足情報

- `/_astro/*` は immutable キャッシュのため、「ヘッダだけ変えるデプロイは既存訪問者のキャッシュ済み資産に反映されない」罠がある (ファイル内コメントに運用メモとして記載)
- Cloudflare Pages の `_headers` は同一パスに複数ルールがマッチすると同名ヘッダが連結されるため、`Cache-Control` は `/*` に置いていない。HTML は Pages 既定 (ETag 再検証) のまま