### PR TITLE
chore(deps): esbuild / fsevents の install script を allowScripts で明示承認

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,5 +54,9 @@
   },
   "overrides": {
     "uuid": "^14.0.0"
+  },
+  "allowScripts": {
+    "esbuild@0.28.1": true,
+    "fsevents@2.3.3": true
   }
 }


### PR DESCRIPTION
## 背景

`npm ci` 実行時に以下の警告が出ていた (#89 の CI ログでも確認)。

```
npm warn allow-scripts 2 packages have install scripts not yet covered by allowScripts:
npm warn allow-scripts   esbuild@0.28.1 (postinstall: node install.js)
npm warn allow-scripts   fsevents@2.3.3 (install: (install scripts present))
```

npm の `allowScripts` フィールド (package.json) は現在 advisory だが、将来のリリースで未承認の install script はブロックされる予定 (`npm help approve-scripts` 参照)。

## 変更内容

`npm approve-scripts esbuild fsevents` (デフォルトの pinned モード) で以下を承認した。

- `esbuild@0.28.1` — postinstall はプラットフォームバイナリの検証/フォールバック (`install.js`)。内容確認済み。
- `fsevents@2.3.3` — 明示的な install script は無く `binding.gyp` による暗黙の node-gyp トリガー検出。prebuilt バイナリ同梱の macOS 専用 optional dependency (vite 経由)。

## 運用上の注意

pinned 承認のため、Renovate が esbuild / fsevents のバージョンを上げると再承認 (`npm approve-scripts <pkg>`) が必要になり、それまで `npm ci` に警告が再出現する。新バージョンの install script に再レビューを強制する意図的な選択。無条件許可にしたい場合は `--no-allow-scripts-pin` で name-only 承認に変更できる。

## 検証

- `npm ci` で allow-scripts 警告が消えることを確認
- `npm approve-scripts --allow-scripts-pending` → `No packages with unreviewed install scripts.`
- `prek run --all-files` 全 hook Passed