### PR TITLE
feat(mise): Cloudflare Pages の preview deployment を削除する cleanup-previews タスクを追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ CI (`.github/workflows/prek.yaml`) でも push / pull request 時に `prek run -
 
 Remove build artifacts (dist/, .astro/)
 
+## `cleanup-previews`
+
+- **Usage**: `cleanup-previews`
+
+Delete Cloudflare Pages preview deployments (latest per branch cannot be deleted and is skipped)
+
 ## `docs`
 
 - **Usage**: `docs`

--- a/mise.lock
+++ b/mise.lock
@@ -162,3 +162,10 @@ checksum = "sha256:872d1c5ac32efce01e93821e790dedc8c055b499f524f1250270679562bf3
 url = "https://github.com/j178/prek/releases/download/v0.4.10/prek-x86_64-pc-windows-msvc.zip"
 url_api = "https://api.github.com/repos/j178/prek/releases/assets/479038029"
 provenance = "github-attestations"
+
+[[tools.wrangler]]
+version = "4.115.0"
+backend = "npm:wrangler"
+
+[tools.wrangler.options]
+allow_builds = '["esbuild", "sharp", "workerd"]'

--- a/mise.toml
+++ b/mise.toml
@@ -6,6 +6,7 @@
 prek = "0.4.10"
 actionlint = "1.7.12"
 dprint = "0.55.2"
+wrangler = "4.115.0"
 
 [env]
 # `mise.local.toml` (git 管理外) を併置すると、ローカルだけの値で上書きできる。
@@ -17,6 +18,34 @@ run = "npm ci"
 [tasks.clean]
 description = "Remove build artifacts (dist/, .astro/)"
 run = "rm -rf dist .astro"
+
+# 各ブランチの最新デプロイは Cloudflare の仕様で削除できないため、スキップして続行する。
+# 認証は wrangler のログインセッション (`wrangler whoami` で確認) を使う。
+[tasks.cleanup-previews]
+description = "Delete Cloudflare Pages preview deployments (latest per branch cannot be deleted and is skipped)"
+run = '''
+#!/usr/bin/env bash
+set -euo pipefail
+project="portfolio"
+list=$(wrangler pages deployment list --project-name "$project" --environment preview)
+ids=$(grep -oE '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' <<<"$list" | sort -u)
+if [[ -z "$ids" ]]; then
+  echo "No preview deployments found."
+  exit 0
+fi
+deleted=0
+skipped=0
+for id in $ids; do
+  if out=$(wrangler pages deployment delete "$id" --project-name "$project" --force 2>&1); then
+    echo "deleted: $id"
+    deleted=$((deleted + 1))
+  else
+    echo "skipped: $id ($(tail -n 1 <<<"$out"))"
+    skipped=$((skipped + 1))
+  fi
+done
+echo "done: deleted=${deleted} skipped=${skipped}"
+'''
 
 [tasks.docs]
 description = "Sync the task list embedded in README.md with mise.toml"


### PR DESCRIPTION
## 概要

Cloudflare Pages の preview deployment は PR マージ後もデプロイと URL が永続し、明示的に削除しない限り残り続ける (公式に retention/TTL 設定は存在しない)。溜まった preview deployment を一括削除する mise task `cleanup-previews` を追加する。

dope-corp/dope-homepage#54 での preview deployment 公開設定の調査から派生した運用改善。dope-corp/dope-homepage#84 と同一の変更。

## 変更内容

- `mise.toml`: `[tools]` に `wrangler = "4.115.0"` を追加 (npm backend)。バージョン未固定の ad-hoc 実行を避け、他ツール同様 Renovate + mise.lock の管理に乗せる
- `mise.toml`: `cleanup-previews` タスクを追加。preview 環境のデプロイを列挙して `wrangler pages deployment delete --force` で順に削除する。ブランチ最新のデプロイは Cloudflare の仕様で削除できないため skipped として続行する。production 環境は対象外
- `README.md`: `mise run docs` でタスク一覧を同期
- `mise.lock`: wrangler のエントリ追加 (mise install による自動更新)

## 検証

- `mise install` 後、`mise exec -- wrangler --version` → 4.115.0
- `wrangler pages deployment list --project-name portfolio --environment preview` が正常終了することを確認 (削除は未実行)

## 備考

- 認証はローカルの wrangler ログインセッション (`wrangler whoami`) を使う。CI で動かす場合は Pages Edit 権限の `CLOUDFLARE_API_TOKEN` が必要