### PR TITLE
chore(deps): allowScripts を name-only 化し strict-allow-scripts で hard fail にする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 
 !/.gitignore
 !/.node-version
+!/.npmrc
 !/README.md
 !/astro.config.mjs
 !/commitlint.config.js

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+; 依存の install script は package.json の allowScripts で承認したものだけ実行する (npm >= 11.16 / RFC 868)。
+; 未承認の install script を持つ依存が入ると install が hard fail する。運用は README の「依存パッケージの install script ポリシー」を参照。
+strict-allow-scripts=true

--- a/README.md
+++ b/README.md
@@ -52,6 +52,18 @@ Git hook は [prek](https://github.com/j178/prek) (`.pre-commit-config.yaml`) �
 
 CI (`.github/workflows/prek.yaml`) でも push / pull request 時に `prek run --all-files` を実行し、全ファイルに対して同じチェックを強制する。
 
+## 依存パッケージの install script ポリシー
+
+npm の `allowScripts` 機構 ([RFC 868](https://github.com/npm/rfcs/pull/868)、npm >= 11.16) を使い、依存パッケージの install script (preinstall / install / postinstall) は `package.json` の `allowScripts` に列挙したパッケージだけに許可する。さらに `.npmrc` の `strict-allow-scripts=true` により、未承認の install script を持つ依存が入ると install は警告ではなく hard fail する (ローカル・CI・Cloudflare ビルドとも)。
+
+install script が必要な依存を新たに追加して install が `ESTRICTALLOWSCRIPTS` で失敗した場合は、script の内容を確認したうえで次のコマンドで承認する。
+
+```shell
+npm approve-scripts <pkg> --no-allow-scripts-pin
+```
+
+エントリはバージョン pin なし (name-only) で登録する。pin 付きにすると Renovate がエントリを追従できず、依存更新のたびに install が壊れるためである。バージョンの固定と更新猶予は lockfile と Renovate の `minimumReleaseAge` (7 日) が担う。
+
 ## タスク
 
 タスクは `mise run <task>` で実行する。

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "uuid": "^14.0.0"
   },
   "allowScripts": {
-    "esbuild@0.28.1": true,
-    "fsevents@2.3.3": true
+    "esbuild": true,
+    "fsevents": true
   }
 }


### PR DESCRIPTION
## 背景

npm v12 (2026-07 リリース) で依存パッケージの install script (preinstall / install / postinstall) が opt-in 化される ([RFC 868](https://github.com/npm/rfcs/pull/868))。未承認の script は **silent skip** となり、postinstall でバイナリを取得・検証する依存が黙って欠落するリスクがある。npm 11.16+ は Phase 1 (警告のみ) を実装済みで、このリポジトリの経路 (CI の `mise exec -- npm ci`、Cloudflare Git 連携ビルド。いずれも `.node-version` の Node 26 → npm 11.17) はすべて対応バージョンで動いている。

#90 で `allowScripts` を pinned モード (`esbuild@0.28.1` / `fsevents@2.3.3`) で承認済みだが、warning-only の Phase 1 を前提とした選択であり、2 つの問題が残っていた。

1. **pin と Renovate automerge の衝突**: Renovate は allowScripts の pin 追従を未サポート。esbuild / fsevents が bump されると pin が外れ、npm v12 では postinstall が silent skip されたまま automerge される (pin による「再承認の強制」は automerge 運用下では形骸化する)
2. **strict 未設定**: 未承認 script は警告止まりで、新規依存が install script を持ち込んでも CI は止まらない

## 変更内容

- `allowScripts` を name-only エントリ (`esbuild` / `fsevents`) に変更。バージョンの固定と更新猶予は lockfile + Renovate の `minimumReleaseAge: 7 days` が既に担っている
- `.npmrc` に `strict-allow-scripts=true` を追加。未承認の install script を持つ依存が入ると install が **hard fail** する (npm 12 デフォルトの silent skip より安全側)。新規依存が install script を持ち込むと Renovate PR も CI で fail し、人手レビューに落ちる
- README に「依存パッケージの install script ポリシー」節と承認手順 (`npm approve-scripts <pkg> --no-allow-scripts-pin`) を追記
- `.gitignore` (ホワイトリスト方式) に `!/.npmrc` を追加

lockfile 上で `hasInstallScript` を持つ依存は esbuild@0.28.1 と fsevents@2.3.3 の 2 つのみで、承認対象に増減はない (dprint は mise 管理のため npm の install script を持たない)。

参照実装: dope-corp/dope-homepage#85

## 検証 (Node 26.4.0 / npm 11.17.0)

- strict の実効性: `allowScripts` から esbuild を一時的に外して `npm ci` → `ESTRICTALLOWSCRIPTS: esbuild@0.28.1 (install: (install scripts present))` で fail することを確認
- 変更後: `.npmrc` の strict 有効状態で `npm ci` → 成功、`npm approve-scripts --allow-scripts-pending` → "No packages with unreviewed install scripts."
- esbuild の動作: `node -e "require('esbuild').version"` → 0.28.1 (postinstall 経路のバイナリ解決が機能)
- `npm run typecheck` / `npm run lint` / `dprint check` / `npm run build` (astro build + pagefind) すべて成功
