### PR TITLE
fix(renovate): lockFileMaintenance で npm の minimumReleaseAge を無効化する

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,6 +26,12 @@
       "matchUpdateTypes": ["patch", "minor"],
       "automerge": true,
       "automergeType": "pr"
+    },
+    {
+      "description": "minimumReleaseAge は npm の lockfile 生成時に --before として渡されるため、lockfile を作り直す lockFileMaintenance では推移的依存が猶予期間前のバージョンへ巻き戻り、公開間もない脆弱性修正版を取り込めず npm audit と衝突する。解決を package manager に委ねる更新種別として、Renovate 公式の security:minimumReleaseAgeNpm preset と同じく猶予期間を無効化する",
+      "matchDatasources": ["npm"],
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "minimumReleaseAge": null
     }
   ],
   "nodenv": {


### PR DESCRIPTION
## 概要

`renovate.json` の `minimumReleaseAge: "7 days"` がトップレベルにあるため lockFileMaintenance にも適用され、lockfile 再生成時に推移的依存が猶予期間より前のバージョンへ巻き戻る。その結果 #96 で nanoid が main の 3.3.18 から 3.3.16 へ退行し、CI の `npm audit --audit-level=high` が落ちていた。

Renovate は npm の lockfile 生成時に `minimumReleaseAge` を `--before=<date>` として渡す ([公式ドキュメント](https://docs.renovatebot.com/key-concepts/minimum-release-age))。通常の依存更新では「既存 lockfile が cutoff より新しいパッケージを含むと npm が失敗し、Renovate が `--before` 無しでリトライする」というフォールバックが効くが、lockFileMaintenance は lockfile を作り直すためこれが効かない。これが main と #96 で nanoid のバージョンが食い違った理由。

## 変更内容

- `packageRules` に、npm datasource の `lockFileMaintenance` に限り `minimumReleaseAge` を `null` にするルールを追加した。Renovate 公式の `security:minimumReleaseAgeNpm` preset と同じ考え方 (「lock file maintenance does not support validating Minimum Release Age, as the package manager performs the required changes」)。
- 直接依存の更新 (minor/patch/major) には従来どおり 7 日の猶予期間が効く。変わるのは lockFileMaintenance 経由の推移的依存のみ。

## 関連 Issue

#96 (この PR のマージ後に rebase すれば CI が通る)

## 動作確認

- 公式スキーマでの検証: `uvx check-jsonschema --schemafile https://docs.renovatebot.com/renovate-schema.json renovate.json` → `ok -- validation done`
  - `renovate-config-validator` 本体は renovate の依存 (re2 / core-js-pure / dtrace-provider) が未承認の install script を持ち、リポジトリの `strict-allow-scripts` で hard fail するため実行していない (バイパスもしていない)。
- prek の pre-commit / commit-msg hook は全て pass。

## チェックリスト

- [ ] テストを追加・更新した (設定ファイルのみの変更のため対象なし)
- [ ] ドキュメントを更新した (`description` フィールドに理由を記載)
- [x] 破壊的変更が含まれる場合、その影響範囲を明記した

## 補足情報

トレードオフ: lockFileMaintenance 経由で更新される推移的依存には、7 日の猶予期間による供給網攻撃対策が効かなくなる。これは Renovate 公式が「package manager の責務」と位置づけている領域であり、実際にも直接依存の更新 PR (#95 / #97) が `--before` 無しのリトライ経路で新しい推移的依存を取り込んでいるため、現状でも猶予は徹底されていない。

`npm audit --audit-level=high` を CI で維持していることが、この緩和に対する後段の防御として機能する。
