### PR TITLE
fix(renovate): lockFileMaintenance のルールを matchManagers でスコープする

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -28,8 +28,8 @@
       "automergeType": "pr"
     },
     {
-      "description": "minimumReleaseAge は npm の lockfile 生成時に --before として渡されるため、lockfile を作り直す lockFileMaintenance では推移的依存が猶予期間前のバージョンへ巻き戻り、公開間もない脆弱性修正版を取り込めず npm audit と衝突する。解決を package manager に委ねる更新種別として、Renovate 公式の security:minimumReleaseAgeNpm preset と同じく猶予期間を無効化する",
-      "matchDatasources": ["npm"],
+      "description": "minimumReleaseAge は npm の lockfile 生成時に --before として渡されるため、lockfile を作り直す lockFileMaintenance では推移的依存が猶予期間前のバージョンへ巻き戻り、公開間もない脆弱性修正版を取り込めず npm audit と衝突する。解決を package manager に委ねる更新種別として猶予期間を無効化する。スコープには matchDatasources を使わないこと: lockFileMaintenance の config は datasource を持たないため matchDatasources を含むルールは決してマッチしない (公式 security:minimumReleaseAgeNpm preset も同じ理由で lockFileMaintenance には効かない)",
+      "matchManagers": ["npm"],
       "matchUpdateTypes": ["lockFileMaintenance"],
       "minimumReleaseAge": null
     }


### PR DESCRIPTION
## 概要

#98 で追加したルールは `matchDatasources: ["npm"]` を含んでいたため、lockFileMaintenance に**一度もマッチしていなかった**。#96 は #98 のマージ後に rebase されたが、lockfile はバイト単位で変わらず nanoid 3.3.16 のままで、CI は同じ箇所で落ち続けている。スコープを `matchManagers` に変更して修正する。

## 原因 (Renovate 44.17.1 のソースで確認)

- `lib/workers/repository/updates/flatten.ts` の lockFileMaintenance ブロックは `packageFileConfig` から config を組み立てており、通常の依存ループ (`mergeChildConfig(packageFileConfig, dep)` + `getDefaultConfig(depConfig.datasource)`) と違って `datasource` を注入しない。設定されるのは `updateType = 'lockFileMaintenance'` と `isLockFileMaintenance = true` のみ。
- `lib/util/package-rules/datasources.ts` の `DatasourcesMatcher` は `datasource` が `undefined` のとき `false` を返す。
- `lib/util/package-rules/index.ts` の `matchesRule` は matcher が falsy を返した時点でルール全体を不成立にする。

したがって `matchDatasources` を含む packageRule は npm の lockFileMaintenance に**構造上マッチしえない**。

一方 `manager` は `lib/config/index.ts` の `getManagerConfig` が `{ ...config, manager }` として無条件に設定するため、`matchManagers` は機能する。`matchUpdateTypes: ["lockFileMaintenance"]` 側は元から正しく、`mergeChildConfig` は `{ ...parentConfig, ...childConfig }` の spread なので `minimumReleaseAge: null` は親の `"7 days"` を正しく上書きする。

## 変更内容

- `matchDatasources: ["npm"]` → `matchManagers: ["npm"]`
- `description` に「matchDatasources を使わないこと」とその理由を明記し、将来同じ罠を踏まないようにした。

## 関連 Issue

#96 / #98

## 動作確認

- 公式スキーマ検証: `uvx check-jsonschema --schemafile https://docs.renovatebot.com/renovate-schema.json renovate.json` → `ok -- validation done`
- 原因の再現 (リポジトリ外の一時ディレクトリに `package.json` のみコピー):
  - `npm install --package-lock-only` → nanoid **3.3.18**
  - `npm install --package-lock-only --before=2026-08-03T02:52:00.000Z` → nanoid **3.3.16**
  - `--before` が外れれば healthy な lockfile になることを確認済み。
- #98 が効いていない証拠: `git diff --stat 1cb0b35 c6f58c2` (設定変更前後の #96 の rebase) が `renovate.json` の 6 行のみで、`package-lock.json` / `mise.lock` は完全一致。

## チェックリスト

- [ ] テストを追加・更新した (設定ファイルのみの変更のため対象なし)
- [ ] ドキュメントを更新した (`description` に理由を記載)
- [x] 破壊的変更が含まれる場合、その影響範囲を明記した

## 補足情報

スコープを `matchManagers: ["npm"]` に限定したため、mise など他マネージャの lockFileMaintenance には引き続き 7 日の猶予期間が効く。`--before` の問題は npm 固有のため、これが最小の変更範囲になる。

公式の `security:minimumReleaseAgeNpm` preset (`lib/config/presets/internal/security.preset.ts`) も打ち消しルールに `matchDatasources: [datasource]` を後付けしており同じ構造の問題を抱えているが、あちらは猶予期間を課す側のルールも同じく `matchDatasources` でスコープされているため、両方効かず結果的に整合している。本リポジトリはトップレベルで `minimumReleaseAge` を設定しており packageRules の成否と無関係に伝播するため、打ち消し側が実際にマッチする必要がある。この upstream の挙動は issue 起票の価値があるかもしれない。
