### PR TITLE
chore(renovate): Mend の実行と重ならない毎日 1 時間の schedule を削除する

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,6 @@
     "helpers:pinGitHubActionDigests"
   ],
   "timezone": "Asia/Tokyo",
-  "schedule": ["* 5 * * *"],
   "separateMajorMinor": true,
   "lockFileMaintenance": {
     "enabled": true


### PR DESCRIPTION
## 概要

renovate の `schedule: ["* 5 * * *"]` (JST 毎日 5 時台の 1 時間のみ) を削除する。

Mend ホスト版 renovate はジョブの実行時刻をリポジトリ側で制御できず、ジョブが window 外に走ると PR が作られない。公式ドキュメントも 1 時間程度の狭い window を明示的に非推奨としている ("Avoid schedules like 'Run Renovate for an hour each Sunday' as you will run into problems" — https://docs.renovatebot.com/key-concepts/scheduling/)。実際に msageha/dotfiles では Mend のジョブ時刻が window と恒常的に重ならず、5 週間 PR が 1 件も作られない事象が発生した。

non-major 更新は既に単一グループ PR + automerge に集約済みのため、PR ノイズ抑制の目的は schedule なしでも維持される。

## 変更内容

- `renovate.json` から `schedule` を削除 (`timezone` は lockFileMaintenance のデフォルト schedule が参照するため残す)

## 関連 Issue

なし

## 動作確認

- `renovate-config-validator` (renovate 44.46.5) で "Config validated successfully" を確認

## チェックリスト

- [ ] テストを追加・更新した (設定変更のみで対象テストなし)
- [ ] ドキュメントを更新した (対象ドキュメントなし)
- [x] 破壊的変更が含まれる場合、その影響範囲を明記した (renovate PR の作成が任意の時間帯に行われるようになる)

## 補足情報

同一の設定を持つ msageha/dotfiles・msageha/portfolio・msageha/local-home-services・msageha/web-tools・dope-corp/template へ横並びで同じ変更を適用している。
